### PR TITLE
Fix documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/internal/server/public_html/
+/config.yaml
+/server

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following steps allow you to run the project:
 - Edit `config.yml` with your desired settings.
 - Run `go generate` to generate the react frontend.
 - Run `go build ./cmd/server`.
-- Run the `./build` binary.
+- Run the `./server` binary.
 - Configure a HTTPS proxy to answer requests on your desired domain.
 - Visit the domain.
 


### PR DESCRIPTION
1. `go build ./cmd/server` generates a binary named `server` not `build`
2. Use gitignore for all documented file changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `.gitignore` file to exclude additional sensitive files and directories from version control.
	- Modified the `README.md` file to reflect the new command for executing the server binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->